### PR TITLE
Fix/composer autoload trailing slashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "commerce365/module-apiextensions",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "N/A",
     "type": "magento2-module",
     "require": {


### PR DESCRIPTION
trailing slashes have been removed from the composer.json file for the correct work of the autoloader
module version has been incremented