### PR TITLE
Fixed incorrect Exception class, needed to come from the global names…

### DIFF
--- a/Model/Category.php
+++ b/Model/Category.php
@@ -18,7 +18,7 @@ class Category implements CategoryManagementInterface
         $category = $objectManager->create('Magento\Catalog\Model\Category')->load($categoryId);
 
         if (!$category->getId())
-            throw new Exception("Category does not exist");
+            throw new \Exception("Category does not exist");
 
         $category->setPosition($new);
 


### PR DESCRIPTION
…pace

Found with running [phpstan](https://github.com/phpstan/phpstan) on level 1:

```
 ------ --------------------------------------------------------------------------------
  Line   module-apiextensions/Model/Category.php
 ------ --------------------------------------------------------------------------------
  21     Instantiated class Commerce365\MagentoApiExtensions\Model\Exception not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------------------
```